### PR TITLE
add restore key for cache restoring

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ async function run() {
             const prefix = '/usr';
             const opt = { cwd: `${process.cwd()}/${gstsrc}` };
             const key = `${github.context.repo.owner}-${github.context.repo.repo}-${gitUrl}-${version}-${arch}-${distro.name}-${distro.versionId}-${mesonVersion}-${keyVersion}`;
-            const cacheKey = await cache.restoreCache([gstsrc], key);
+            const cacheKey = await cache.restoreCache([gstsrc], key, [key]);
 
             if (!cacheKey) {
               core.info(`Pre-built not found in cache; creating a new one. (key: "${key}")`);


### PR DESCRIPTION
## Description

we have a lot of gstreamer caches in https://github.com/go-gst/go-gst/actions/caches but the caches were not used and the build times for ubuntu-latest were >25min since gstreamer was built all the time

e.g.: https://github.com/go-gst/go-gst/actions/runs/6050337478/job/16419459150#step:3:16 (16min setup gstreamer)

```
 Pre-built not found in cache; creating a new one. (key: "go-gst-go-gst-https://gitlab.freedesktop.org/gstreamer/gstreamer.git-1.22.0-x86_64-Ubuntu-22.04-meson-1.2.1-1")
```

Although that key exists a lot in the cache files.

## Fix

this PR addresses this issue by adding a restore key to the cache restore call. I experimented in https://github.com/go-gst/go-gst/pull/35 with my fork and now the action only takes 52sec: https://github.com/go-gst/go-gst/actions/runs/6052196157/job/16425193945?pr=35