### PR TITLE
Make dependabot update dist automatically

### DIFF
--- a/.github/workflows/update-dist-on-dependabot.yml
+++ b/.github/workflows/update-dist-on-dependabot.yml
@@ -1,0 +1,42 @@
+name: Update action dist on dependabot PRs
+on:
+  push:
+    branches:
+      - dependabot/npm_and_yarn/**
+  pull_request:
+    branches:
+      - dependabot/npm_and_yarn/**
+
+
+jobs:
+  update-action-dist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ACTIONS_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_APP_PEM }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Update action dist
+        run: npm ci && npm run prepare
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Update action dist
+          branch: ${{ github.head_ref }}
+          commit_user_name: ${{ github.actor }}
+          commit_user_email: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
   forceBuildFromSource:
     description: 'whether to force building from source instead of using installer package'
     required: false
-    default: false
+    default: 'false'
   gstreamerOptions:
     description: 'The option configuration string for buliding GStreamer from source'
     required:    false


### PR DESCRIPTION
The existing dependabot PRs are failing the [`check-dist`](https://github.com/blinemedical/setup-gstreamer/actions/runs/7803240935/job/21282566722) required build step.  This adds a workflow triggered by dependabot branches and PRs to automatically prepare and check in the updated dist. The commit author is set to the user that triggered the workflow (dependabot) so that it won't disrupt the other dependabot actions (auto-update, etc).

You can see that [this PR](https://github.com/blinemedical/setup-gstreamer/pull/173) matching the branch naming requirements triggers the [workflow run](https://github.com/blinemedical/setup-gstreamer/actions/runs/7807624059/job/21296353770) automatically pushed a [commit](https://github.com/blinemedical/setup-gstreamer/pull/173/commits/666f033f3f1bc681edaabf4d260d2e7850028f3d) updating the dist.